### PR TITLE
renames offers in the dashboard

### DIFF
--- a/views/dashboard.hbs
+++ b/views/dashboard.hbs
@@ -20,7 +20,7 @@
     <!-- Offers Received -->
     <div class="card m-4 w-30 flex-fill">
         <div class="card-header">
-            <h4>Offers Received</h4>
+            <h4>Open Offers</h4>
         </div>
         <div class="card-body">
             <h4>{{ offerCount }}</h4>


### PR DESCRIPTION
## Purpose

Renames 'Offers Received' on the Dashboard to 'Open Offers' so that it's more clear that we're counting only applications with the 'Offer Received' status and excluding applications with a status of 'Offer Accepted' or 'Offer Rejected'

Fixes #187
